### PR TITLE
Separate ocis and old web urls

### DIFF
--- a/cboxredirectd/main.go
+++ b/cboxredirectd/main.go
@@ -34,6 +34,7 @@ func init() {
 	gc.Add("new-proxy", "", "server to forward requests for migrated/new users")
 	gc.Add("web-proxy", "", "server to forward requests for web UI/API")
 	gc.Add("web-canary-proxy", "", "server to forward requests for web canary UI/API")
+	gc.Add("web-ocis-regex", "new(qa)?.cernbox.cern.ch", "Regex to identify the an ocis path given a request' hostname")
 	gc.Add("web-ocis-proxy", "", "server to forward requests for web OCIS UI/API")
 	gc.Add("http-read-timeout", 300, "the maximum duration for reading the entire request, including the body.")
 	gc.Add("http-write-timeout", 300, "the maximum duration before timing out writes of the response.")
@@ -181,6 +182,7 @@ func newProxyHandler(migrator api.Migrator) http.Handler {
 		WebProxyURL:         gc.GetString("web-proxy"),
 		WebCanaryProxyURL:   gc.GetString("web-canary-proxy"),
 		WebOCISProxyURL:     gc.GetString("web-ocis-proxy"),
+		OcisRegex:           gc.GetString("web-ocis-regex"),
 		DisableKeepAlives:   gc.GetBool("proxy-disable-keep-alives"),
 		MaxIdleConns:        gc.GetInt("proxy-max-idle-conns"),
 		MaxIdleConnsPerHost: gc.GetInt("proxy-max-idle-conns-per-host"),


### PR DESCRIPTION
After, we can change the regex and we automatically flip the old web with ocis in the cernbox.cern.ch domain.
My only doubt is wether we want to make the sync client calls still go through the old instead of ocis in the medium term (after making ocis the default url). We can change that later, or we just check wether the path starts with /cernbox/[desktop,mobile].