### PR TITLE
Fix sync client

### DIFF
--- a/api/proxy/proxy.go
+++ b/api/proxy/proxy.go
@@ -21,7 +21,6 @@ type Options struct {
 	WebProxyURL         string
 	WebCanaryProxyURL   string
 	WebOCISProxyURL     string
-	ApiProxyURL         string
 	OcisRegex           string
 	OcisRedirect        string
 	OldInfraRegex       string
@@ -47,7 +46,6 @@ type proxy struct {
 	webProxy           *httputil.ReverseProxy
 	webCanaryProxy     *httputil.ReverseProxy
 	webOCISProxy       *httputil.ReverseProxy
-	apiProxy           *httputil.ReverseProxy
 	ocisRegex          *regexp.Regexp
 	ocisRedirect       string
 	oldInfraRegex      *regexp.Regexp
@@ -115,10 +113,6 @@ func New(opts *Options) (http.Handler, error) {
 	if err != nil {
 		return nil, err
 	}
-	apiURL, err := url.Parse(opts.ApiProxyURL)
-	if err != nil {
-		return nil, err
-	}
 
 	t := &http.Transport{
 		DisableKeepAlives:   opts.DisableKeepAlives,
@@ -133,13 +127,11 @@ func New(opts *Options) (http.Handler, error) {
 	webProxy := newSingleHostReverseProxy(webURL)
 	webCanaryProxy := newSingleHostReverseProxy(webCanaryURL)
 	webOCISProxy := newSingleHostReverseProxy(webOCISURL)
-	apiProxy := newSingleHostReverseProxy(apiURL)
 
 	eosProxy.Transport = t
 	webProxy.Transport = t
 	webCanaryProxy.Transport = t
 	webOCISProxy.Transport = t
-	apiProxy.Transport = t
 
 	ocisRegex, err := regexp.Compile(opts.OcisRegex)
 	if err != nil {
@@ -163,7 +155,6 @@ func New(opts *Options) (http.Handler, error) {
 		webProxy:           webProxy,
 		webCanaryProxy:     webCanaryProxy,
 		webOCISProxy:       webOCISProxy,
-		apiProxy:           apiProxy,
 		ocisRegex:          ocisRegex,
 		ocisRedirect:       opts.OcisRedirect,
 		oldInfraRegex:      oldInfraRegex,
@@ -196,17 +187,6 @@ func (p *proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Redirect(w, r, p.ocisRedirect+r.URL.String(), http.StatusMovedPermanently)
 		return
 	}
-
-	// cernbox/desktop/ocs/
-	// cernbox/mobile/ocs/
-	if ok, trim := p.isApiPath(normalizedPath); ok {
-		p.logger.Info("request goes to api proxy", zap.String("path", normalizedPath))
-		r.URL.Path = strings.TrimPrefix(r.URL.Path, trim)
-		p.apiProxy.ServeHTTP(w, r)
-		return
-	}
-
-	// TODO:  hook here to send to ocs requests from desktop to OCIS api instead of old server
 
 	// old infra contains host-based regex (old.cernbox.cern.ch) and also
 	// "/cernbox/desktop", "/cernbox/mobile", "/cernbox/webdav", "/swanapi", "/cernbox/update", "/cernbox/doc",
@@ -297,12 +277,6 @@ var knownOldPaths = []string{
 	"/cernbox/doc",
 }
 
-// key is path to match and value is prefix to trim from request
-var apiMap = map[string]string{
-	"/cernbox/desktop/ocs/": "/cernbox/desktop",
-	"/cernbox/mobile/ocs/":  "/cernbox/mobile",
-}
-
 var eosDav = []string{
 	"/cernbox/desktop/remote.php/dav",
 	"/cernbox/desktop/remote.php/webdav",
@@ -326,15 +300,6 @@ func (p *proxy) isWebRequest(path string, r *http.Request) bool {
 
 func (p *proxy) isTemporaryURL(r *http.Request) bool {
 	return p.ocisRegex.MatchString(r.Host)
-}
-
-func (p *proxy) isApiPath(path string) (bool, string) {
-	for match, trim := range apiMap {
-		if strings.HasPrefix(path, match) {
-			return true, trim
-		}
-	}
-	return false, ""
 }
 
 func (p *proxy) isOldInfra(path string, r *http.Request) bool {

--- a/api/proxy/proxy.go
+++ b/api/proxy/proxy.go
@@ -19,7 +19,6 @@ import (
 type Options struct {
 	EosProxyURL         string
 	WebProxyURL         string
-	WebCanaryProxyURL   string
 	WebOCISProxyURL     string
 	OcisRegex           string
 	OcisRedirect        string
@@ -44,7 +43,6 @@ func (opts *Options) init() {
 type proxy struct {
 	eosProxy           *httputil.ReverseProxy
 	webProxy           *httputil.ReverseProxy
-	webCanaryProxy     *httputil.ReverseProxy
 	webOCISProxy       *httputil.ReverseProxy
 	ocisRegex          *regexp.Regexp
 	ocisRedirect       string
@@ -105,10 +103,6 @@ func New(opts *Options) (http.Handler, error) {
 	if err != nil {
 		return nil, err
 	}
-	webCanaryURL, err := url.Parse(opts.WebCanaryProxyURL)
-	if err != nil {
-		return nil, err
-	}
 	webOCISURL, err := url.Parse(opts.WebOCISProxyURL)
 	if err != nil {
 		return nil, err
@@ -125,12 +119,10 @@ func New(opts *Options) (http.Handler, error) {
 
 	eosProxy := newSingleHostReverseProxy(eosURL)
 	webProxy := newSingleHostReverseProxy(webURL)
-	webCanaryProxy := newSingleHostReverseProxy(webCanaryURL)
 	webOCISProxy := newSingleHostReverseProxy(webOCISURL)
 
 	eosProxy.Transport = t
 	webProxy.Transport = t
-	webCanaryProxy.Transport = t
 	webOCISProxy.Transport = t
 
 	ocisRegex, err := regexp.Compile(opts.OcisRegex)
@@ -153,7 +145,6 @@ func New(opts *Options) (http.Handler, error) {
 	return &proxy{
 		eosProxy:           eosProxy,
 		webProxy:           webProxy,
-		webCanaryProxy:     webCanaryProxy,
 		webOCISProxy:       webOCISProxy,
 		ocisRegex:          ocisRegex,
 		ocisRedirect:       opts.OcisRedirect,

--- a/cboxredirectd/main.go
+++ b/cboxredirectd/main.go
@@ -30,7 +30,6 @@ func init() {
 	gc.Add("log-level", "info", "log level to use (debug, info, warn, error)")
 	gc.Add("eos-proxy", "", "server to forward dav requests or unkown requests")
 	gc.Add("web-proxy", "", "server to forward requests for web UI/API")
-	gc.Add("web-canary-proxy", "", "server to forward requests for web canary UI/API")
 	gc.Add("web-ocis-regex", "new(qa)?.cernbox.cern.ch", "Regex to identify the an ocis path given a request' hostname")
 	gc.Add("web-ocis-redirect", "cernbox.cern.ch", "URL to redirect the ocis requests to")
 	gc.Add("old-infra-regex", "old(qa)?.cernbox.cern.ch", "Regex to identify the old infra given a request' hostname")
@@ -143,7 +142,6 @@ func newProxyHandler() http.Handler {
 		Logger:              logger,
 		EosProxyURL:         gc.GetString("eos-proxy"),
 		WebProxyURL:         gc.GetString("web-proxy"),
-		WebCanaryProxyURL:   gc.GetString("web-canary-proxy"),
 		WebOCISProxyURL:     gc.GetString("web-ocis-proxy"),
 		OcisRegex:           gc.GetString("web-ocis-regex"),
 		OcisRedirect:        gc.GetString("web-ocis-redirect"),

--- a/cboxredirectd/main.go
+++ b/cboxredirectd/main.go
@@ -35,7 +35,6 @@ func init() {
 	gc.Add("web-ocis-redirect", "cernbox.cern.ch", "URL to redirect the ocis requests to")
 	gc.Add("old-infra-regex", "old(qa)?.cernbox.cern.ch", "Regex to identify the old infra given a request' hostname")
 	gc.Add("web-ocis-proxy", "", "server to forward requests for web OCIS UI/API")
-	gc.Add("api-proxy", "https://api.cernbox.cern.ch", "server to forward requests for api")
 	gc.Add("http-read-timeout", 300, "the maximum duration for reading the entire request, including the body.")
 	gc.Add("http-write-timeout", 300, "the maximum duration before timing out writes of the response.")
 	gc.Add("tls-cert", "/etc/grid-security/hostcert.pem", "TLS certificate to encrypt connections.")
@@ -146,7 +145,6 @@ func newProxyHandler() http.Handler {
 		WebProxyURL:         gc.GetString("web-proxy"),
 		WebCanaryProxyURL:   gc.GetString("web-canary-proxy"),
 		WebOCISProxyURL:     gc.GetString("web-ocis-proxy"),
-		ApiProxyURL:         gc.GetString("api-proxy"),
 		OcisRegex:           gc.GetString("web-ocis-regex"),
 		OcisRedirect:        gc.GetString("web-ocis-redirect"),
 		OldInfraRegex:       gc.GetString("old-infra-regex"),


### PR DESCRIPTION
I reverted your last changes.
I remember you saying that it was not working to config a client from 0, but I just tried and is ok. But it requires a new ocproxy + new puppet config. Maybe one of those was out of sync so you didn't see it working. We need to review all PRs and merge + tag new version to properly test the full stack.

I propose we make this work first and then we proceed to move to the newer infra.